### PR TITLE
Increase description character limit to 500 for tracks and session format

### DIFF
--- a/app/models/session_format.rb
+++ b/app/models/session_format.rb
@@ -4,7 +4,7 @@ class SessionFormat < ApplicationRecord
   has_many :proposals
 
   validates_presence_of :event
-  validates :description, length: { maximum: 250 }
+  validates :description, length: { maximum: 500 }
   validates :name, uniqueness: {scope: :event}, presence: true
 
   scope :sort_by_name, ->{ order(:name) }

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -6,7 +6,7 @@ class Track < ApplicationRecord
   has_many :proposals
 
   validates :name, uniqueness: {scope: :event}, presence: true
-  validates :description, length: {maximum: 250}
+  validates :description, length: {maximum: 500}
 
   scope :sort_by_name, -> { order(:name) }
 
@@ -22,7 +22,7 @@ end
 #  id          :bigint(8)        not null, primary key
 #  event_id    :bigint(8)
 #  name        :string
-#  description :string(250)
+#  description :string(500)
 #  guidelines  :text
 #  created_at  :datetime
 #  updated_at  :datetime

--- a/app/views/staff/tracks/_form.html.haml
+++ b/app/views/staff/tracks/_form.html.haml
@@ -1,6 +1,6 @@
 = f.input :name, placeholder: "Name", autofocus: true
 = f.input :description, as: :text, input_html: {rows: 6}, placeholder: "Description",
-  hint: "Brief description (fewer than 250 characters)"
+  hint: "Brief description (fewer than 500 characters)"
 = f.input :guidelines, as: :text, input_html: {rows: 12}, placeholder: "Guidelines",
   hint: "A more detailed description of the track that will appear in the Event Guidelines."
 .modal-footer

--- a/db/migrate/20260209000000_increase_track_description_limit_to_500.rb
+++ b/db/migrate/20260209000000_increase_track_description_limit_to_500.rb
@@ -1,0 +1,9 @@
+class IncreaseTrackDescriptionLimitTo500 < ActiveRecord::Migration[5.1]
+  def up
+    change_column :tracks, :description, :string, limit: 500
+  end
+
+  def down
+    change_column :tracks, :description, :string, limit: 250
+  end
+end

--- a/spec/features/staff/event_config_spec.rb
+++ b/spec/features/staff/event_config_spec.rb
@@ -88,18 +88,18 @@ feature "Event Config" do
       end
     end
 
-    it "can't add a track with a description longer than 250 characters" do
+    it "can't add a track with a description longer than 500 characters" do
       visit event_staff_config_path(event)
       find_link("Add Track").click
 
       find("#track_name")
       fill_in "Name", with: "Best Session"
       find("#track_description")
-      fill_in "Description", with: ("s" * 251 + "i")
+      fill_in "Description", with: ("s" * 501 + "i")
       find_button("Save").click
 
-      expect(page).to have_content("Description is too long (maximum is 250 characters)")
-      # expect(page).to have_content("There was a problem saving your track, Description is too long (maximum is 250 characters).")
+      expect(page).to have_content("Description is too long (maximum is 500 characters)")
+      # expect(page).to have_content("There was a problem saving your track, Description is too long (maximum is 500 characters).")
     end
 
     it "can edit a track" do
@@ -133,7 +133,7 @@ feature "Event Config" do
       expect(page).to have_content("Name can't be blank.")
     end
 
-    it "can't edit description to be longer than 250 characters" do
+    it "can't edit description to be longer than 500 characters" do
       track = create(:track, event: event)
       visit event_staff_config_path(event)
 
@@ -144,11 +144,11 @@ feature "Event Config" do
       find("#track_name").native.clear
       fill_in "track_name", with: track.name
       find("#track_description").native.clear
-      fill_in "track_description", with: ("s" * 250 + "i")
+      fill_in "track_description", with: ("s" * 500 + "i")
       find_button("Save").click
 
-      expect(page).to have_content("Description is too long (maximum is 250 characters)")
-      # expect(page).to have_content("There was a problem updating your track, Description is too long (maximum is 250 characters).")
+      expect(page).to have_content("Description is too long (maximum is 500 characters)")
+      # expect(page).to have_content("There was a problem updating your track, Description is too long (maximum is 500 characters).")
     end
 
     it "can delete a track" do


### PR DESCRIPTION
The previous 250 character limit was too restrictive for detailed track and session format descriptions. This raises it to 500 characters in both model validations and updates the corresponding form hint and tests.

done w Claudito